### PR TITLE
fix: fortune details type 지정

### DIFF
--- a/src/fortune/entities/enums.py
+++ b/src/fortune/entities/enums.py
@@ -8,3 +8,10 @@ class FortuneType(str, Enum):
     LUCKY_OBJECT = "행운의 오브제"
     PERFECT_TIMING = "절호의 타이밍"
     TABOO_OF_DAY = "오늘의 금기"
+
+
+class FortuneDetailType(str, Enum):
+    """운세 상세 항목 타입"""
+    MONEY = "money"
+    JOB = "job"
+    LOVE = "love"

--- a/src/fortune/entities/schemas.py
+++ b/src/fortune/entities/schemas.py
@@ -2,7 +2,7 @@
 from datetime import date
 from typing import List, Optional, Dict
 from src.config.schemas import CommonBase
-from src.fortune.entities.enums import FortuneType
+from src.fortune.entities.enums import FortuneType, FortuneDetailType
 
 
 class DailyFortuneResource(CommonBase):
@@ -39,10 +39,18 @@ class UserDailyFortuneSummary(CommonBase):
     image_url: str
     description: str
 
+
+class FortuneDetailItem(CommonBase):
+    """운세 상세 항목"""
+    type: FortuneDetailType
+    title: str
+    content: str
+
+
 class UserDailyFortuneDetail(CommonBase):
     id: int
     user_id: str
     fortune_date: date
     fortune_score: int
     fortune_comment: str
-    fortune_details: Dict[str, str]
+    fortune_details: List[FortuneDetailItem]

--- a/src/fortune/repository.py
+++ b/src/fortune/repository.py
@@ -159,7 +159,7 @@ class FortuneRepository:
         fortune_date: date,
         fortune_score: int,
         fortune_comment: str,
-        fortune_details: dict,
+        fortune_details: List[dict],
     ) -> UserDailyFortuneDetailModel:
         """사용자 운세 상세 정보 생성"""
         model = UserDailyFortuneDetailModel(


### PR DESCRIPTION
## 📍 작업 배경  [#](#background) <span id="background"></span>
<!-- 관련 이슈 링크 및 작업하게 된 이유/배경 설명 -->
- issue : #



## 📝 작업 내용  [#](#work_detail) <span id="work_detail"></span>
<!-- 주요 구현 사항 설명 -->
<!-- 필요 시, 응답값 예시 첨부 -->
GET `/users/{user_id}/daily-fortune-details` resposne 형식 변경
```json
{
  "id": 4,
  "user_id": "strin",
  "fortune_date": "2025-08-17",
  "fortune_score": 60,
  "fortune_comment": "불같은 성격 때문에 손해볼 수 있소.",
  "fortune_details": [
    {
      "type": "money",
      "title": "재물운",
      "content": "지출이 많았소"
    },
    {
      "type": "job",
      "title": "취업운",
      "content": "갈등 발생 가능성 높음"
    },
    {
      "type": "love",
      "title": "연애운",
      "content": "감정 조절 필요"
    }
  ]
}
```
cc. @JGeun 
## 💬 코멘트 [#](#comments) <span id="comments"></span>
<!-- 리뷰어에게 전달하고 싶은 사항, 리뷰 시 확인해야 하는 사항, 궁금한 사항 등-->
