### PR TITLE
fix: 추천 여러번 생성한 경우 읽음 버그 해결

### DIFF
--- a/src/lotto/repository.py
+++ b/src/lotto/repository.py
@@ -204,16 +204,22 @@ class LottoRepository:
                 LottoRecommendations.user_id == user_id,
                 LottoRecommendations.round == round,
             )
+            .order_by(desc(LottoRecommendations.created_at))
             .limit(1)
         )
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
-    async def mark_recommendation_read(self, recommendation_id: int, read_at: datetime) -> None:
-        """추천 레코드를 읽음 처리합니다."""
+    async def mark_all_recommendations_read_by_user_and_round(
+            self, user_id: str, round: int, read_at: datetime
+    ) -> None:
+        """특정 사용자와 회차의 모든 추천을 읽음 처리합니다."""
         stmt = (
             update(LottoRecommendations)
-            .where(LottoRecommendations.id == recommendation_id)
+            .where(
+                LottoRecommendations.user_id == user_id,
+                LottoRecommendations.round == round,
+            )
             .values(is_read=True, read_at=read_at)
         )
         await self.session.execute(stmt)

--- a/src/lotto/service.py
+++ b/src/lotto/service.py
@@ -380,13 +380,12 @@ class LottoService:
         rank = self._judge_rank(matched_count, has_bonus)
         prize_amount = self._pick_prize_amount(draw, rank)
 
-        # 5) 읽음 처리
-        if not rec.is_read:
-            kst = ZoneInfo("Asia/Seoul")
-            await self.lotto_repository.mark_recommendation_read(
-                rec.id, read_at=datetime.now(tz=kst)
-            )
-            # 필요 시: await self.lotto_repository.session.commit()
+        # 5) 읽음 처리 - 해당 라운드의 모든 추천을 읽음 처리
+        kst = ZoneInfo("Asia/Seoul")
+        await self.lotto_repository.mark_all_recommendations_read_by_user_and_round(
+            user_id=user_id, round=round, read_at=datetime.now(tz=kst)
+        )
+        # 필요 시: await self.lotto_repository.session.commit()
 
         # 6) 응답
         return LottoResultCheckResponse(


### PR DESCRIPTION
## 📍 작업 배경  [#](#background) <span id="background"></span>
<!-- 관련 이슈 링크 및 작업하게 된 이유/배경 설명 -->
- issue : #
https://discord.com/channels/1393454121025015860/1414233496934678578/1415545331093078106
로또 결과 확인 이후에도 이전 응답으로 계속 내려오는 버그 수정


## 📝 작업 내용  [#](#work_detail) <span id="work_detail"></span>
<!-- 주요 구현 사항 설명 -->
<!-- 필요 시, 응답값 예시 첨부 -->

- 로또 결과는 최신순으로만 조회
- 여러번 추천받은 경우 대응을 위해 로또 결과 확인 시 해당 회차의 모든 추천결과 읽음 처리

## 💬 코멘트 [#](#comments) <span id="comments"></span>
<!-- 리뷰어에게 전달하고 싶은 사항, 리뷰 시 확인해야 하는 사항, 궁금한 사항 등-->
